### PR TITLE
Finish implementation of WARMBOOT cells

### DIFF
--- a/src/global.cc
+++ b/src/global.cc
@@ -93,6 +93,9 @@ Promoter::port_gc(Port *conn, bool indirect)
 	  || conn->name() == "OUTPUT_CLOCK")
 	return gc_clk;
     }
+  else if (models.is_warmboot(inst))
+    {
+    }
   else
     {
       assert(models.is_ramX(inst));

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -1003,6 +1003,11 @@ Design::create_standard_models()
 	bram->set_param("READ_MODE", BitVector(2, 0));
 	bram->set_param("WRITE_MODE", BitVector(2, 0));
       }
+
+  Model *warmboot = new Model(this, "SB_WARMBOOT");
+  warmboot->add_port("BOOT", Direction::IN, Value::ZERO);
+  warmboot->add_port("S1", Direction::IN, Value::ZERO);
+  warmboot->add_port("S0", Direction::IN, Value::ZERO);
 }
 
 Model *
@@ -1058,4 +1063,5 @@ Models::Models(Design *d)
   ramnr = d->find_model("SB_RAM40_4KNR");
   ramnw = d->find_model("SB_RAM40_4KNW");
   ramnrnw = d->find_model("SB_RAM40_4KNRNW");
+  warmboot = d->find_model("SB_WARMBOOT");
 }

--- a/src/netlist.hh
+++ b/src/netlist.hh
@@ -418,7 +418,8 @@ public:
     *ram,
     *ramnr,
     *ramnw,
-    *ramnrnw;
+    *ramnrnw,
+    *warmboot;
   
 public:
   Models(Design *d);
@@ -437,6 +438,7 @@ public:
   bool is_ramnr(Instance *inst) const { return inst->instance_of() == ramnr; }
   bool is_ramnw(Instance *inst) const { return inst->instance_of() == ramnw; }
   bool is_ramnrnw(Instance *inst) const { return inst->instance_of() == ramnrnw; }
+  bool is_warmboot(Instance *inst) const { return inst->instance_of() == warmboot; }
   
   bool is_ramX(Instance *inst) const
   { 

--- a/src/pack.cc
+++ b/src/pack.cc
@@ -567,7 +567,8 @@ Packer::pack()
     n_lc_dff = 0,
     n_lc_carry_dff = 0,
     n_gb = 0,
-    n_bram = 0;
+    n_bram = 0,
+    n_warmboot = 0;
   for (Instance *inst : top->instances())
     {
       if (models.is_lc(inst))
@@ -590,6 +591,8 @@ Packer::pack()
 	++n_io;
       else if (models.is_gb(inst))
 	++n_gb;
+      else if (models.is_warmboot(inst))
+	++n_warmboot;
       else
 	{ 
 	  assert(models.is_ramX(inst));
@@ -604,6 +607,13 @@ Packer::pack()
 	++n_logic_tiles;
     }
   
+  int n_warmboot_cells = 0;
+  for (int i = 0; i < chipdb->n_cells; ++i)
+    {
+      if (chipdb->cell_type[i+1] == CellType::WARMBOOT)
+	++n_warmboot_cells;
+    }
+
   *logs << "\nAfter packing:\n"
 	<< "IOs          " << n_io << " / " << package.pin_loc.size() << "\n"
 	<< "LCs          " << n_lc << " / " << n_logic_tiles*8 << "\n"
@@ -613,6 +623,7 @@ Packer::pack()
 	<< "  DFF PASS   " << n_dff_pass_through << "\n"
 	<< "  CARRY PASS " << n_carry_pass_through << "\n"
 	<< "BRAMs        " << n_bram << " / " << n_ramt_tiles << "\n"
+	<< "WARMBOOTs    " << n_warmboot << " / " << n_warmboot_cells << "\n"
 	<< "GBs          " << n_gb << " / " << chipdb->n_global_nets << "\n\n";
 }
 

--- a/src/place.cc
+++ b/src/place.cc
@@ -156,6 +156,8 @@ Placer::gate_cell_type(int g)
     return CellType::IO;
   else if (models.is_gb(inst))
     return CellType::GB;
+  else if (models.is_warmboot(inst))
+    return CellType::WARMBOOT;
   else
     {
       assert(models.is_ramX(inst));
@@ -918,7 +920,8 @@ Placer::place_initial()
 	      cell_gate[c] = i;
 	      gate_cell[i] = c;
 	      
-	      if (!valid(chipdb->cell_location[c].tile()))
+	      if (ct != CellType::WARMBOOT &&
+		  !valid(chipdb->cell_location[c].tile()))
 		cell_gate[c] = 0;
 	      else
 		{
@@ -999,6 +1002,11 @@ Placer::configure()
       int cell = gate_cell[g];
       const Location &loc = chipdb->cell_location[cell];
       
+      if (models.is_warmboot(inst)) {
+	placement[inst] = cell;
+	continue;
+      }
+
       int t = loc.tile();
       const auto &func_cbits = chipdb->tile_nonrouting_cbits.at(chipdb->tile_type[t]);
       

--- a/src/route.cc
+++ b/src/route.cc
@@ -191,6 +191,18 @@ Router::port_cnet(Instance *inst, Port *p)
 	  tile_net_name = fmt("glb_netwk_" << g);
 	}
     }
+  else if (models.is_warmboot(inst))
+    {
+      auto xcell = std::find(chipdb->extra_cell_tile.begin(),
+			    chipdb->extra_cell_tile.end(), t);
+      assert(xcell != chipdb->extra_cell_tile.end());
+      const auto &mfvs =
+	chipdb->extra_cell_mfvs[xcell - chipdb->extra_cell_tile.begin()];
+      auto mfv = mfvs.find(p_name);
+      assert(mfv != mfvs.end());
+      t = mfv->second.first;
+      tile_net_name = mfv->second.second;
+    }
   else
     {
       assert(models.is_ramX(inst));


### PR DESCRIPTION
Hi.  I added the missing stuff to be able to generate bitstreams using the SB_WARMBOOT module.

The slighly weird code in `place.cc` is due to the fact that the WARMBOOT cell does not have a valid tile (it is 0 0), so it's not possible to call `valid()` on the tile, or to lookup the nonrouting cbits for the the tile type.

Tested on iCEstick iCE40HX1K.