### PR TITLE
Fix overlap check in Placer::chain_random_loc

### DIFF
--- a/src/place.cc
+++ b/src/place.cc
@@ -213,8 +213,7 @@ Placer::chain_random_loc(int c)
       int e_nt = (chains.chains[e].size() + 7) / 8;
       int e_start = chain_start[e],
         e_end = e_start + e_nt - 1;
-      if ((new_start > e_start && new_start <= e_end)
-          || (new_end >= e_start && new_end < e_end))
+      if (e_start <= new_end && new_start <= e_end)
         return std::make_pair(Location(), false);
     }
   


### PR DESCRIPTION
The current check can return a false negative if

- `new_start == e_start && new_end == e_end` (ranges are the same)
- `new_start < e_start && new_end > e_end` (new range encompasses element range)

Not sure if this can cause any problems (probably, placement failures are handled later) but I noticed this while reading the code. The new check is more efficient as well.