### PR TITLE
Fix chipdb read failure on Windows

### DIFF
--- a/src/arachne-pnr.cc
+++ b/src/arachne-pnr.cc
@@ -349,7 +349,7 @@ main(int argc, const char **argv)
       *logs << "write_binary_chipdb " << binary_chipdb << "\n";
       
       std::string expanded = expand_filename(binary_chipdb);
-      std::ofstream ofs(expanded);
+      std::ofstream ofs(expanded, std::ofstream::out | std::ofstream::binary);
       if (ofs.fail())
         fatal(fmt("write_binary_chidpb: failed to open `" << expanded << "': "
                   << strerror(errno)));

--- a/src/chipdb.cc
+++ b/src/chipdb.cc
@@ -985,7 +985,7 @@ ChipDB *
 read_chipdb(const std::string &filename)
 {
   std::string expanded = expand_filename(filename);
-  std::ifstream ifs(expanded);
+  std::ifstream ifs(expanded, std::ifstream::in | std::ifstream::binary);
   if (ifs.fail())
     fatal(fmt("read_chipdb: failed to open `" << expanded << "': "
               << strerror(errno)));


### PR DESCRIPTION
Windows will convert `\n` to `\r\n` and vice versa on read/write in text mode, binary mode must be stated explicitly to prevent this. This fixes #28 