### PR TITLE
Support for 64-bit size_t offsets in bstream.hh

### DIFF
--- a/src/bstream.hh
+++ b/src/bstream.hh
@@ -149,6 +149,11 @@ inline obstream &operator<<(obstream &obs, unsigned long x)
   return bwrite_unsigned_integral_type<unsigned long>(obs, x);
 }
 
+inline obstream &operator<<(obstream &obs, unsigned long long x)
+{
+  return bwrite_unsigned_integral_type<unsigned long long>(obs, x);
+}
+
 inline obstream &operator<<(obstream &obs, const std::string &s)
 {
   obs << s.size();
@@ -306,6 +311,11 @@ inline ibstream &operator>>(ibstream &ibs, long &x)
 inline ibstream &operator>>(ibstream &ibs, unsigned long &x)
 {
   return bread_unsigned_integral_type<unsigned long>(ibs, x);
+}
+
+inline ibstream &operator>>(ibstream &ibs, unsigned long long &x)
+{
+  return bread_unsigned_integral_type<unsigned long long>(ibs, x);
 }
 
 inline ibstream &operator>>(ibstream &ibs, std::string &s)


### PR DESCRIPTION
On 64-bit systems the 'size_t' type is translated to 'unsigned long long', therefore there is need for additional overload of '>>' nad '<<' operators.
This change was tested on mingw-w64-gcc-6.1.0 toolchain and works as expected.