### PR TITLE
output unknown BLIF directives in error messages

### DIFF
--- a/src/blif.cc
+++ b/src/blif.cc
@@ -284,7 +284,7 @@ BlifParser::parse()
               goto M;
             }
           else
-            fatal("unknown directive");
+            fatal(fmt("unknown directive '" << cmd << "'"));
         }
       else
         fatal("expected directive");


### PR DESCRIPTION
Replacing "fatal error: unknown directive"
by more meaningfull "fatal error: unknown directive '.subckt'"...