### PR TITLE
Fixed VER -> ARCHNE_VER in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ICEBOX ?= $(PREFIX)/share/icebox
 .PHONY: all
 all: bin/arachne-pnr share/arachne-pnr/chipdb-384.bin share/arachne-pnr/chipdb-1k.bin share/arachne-pnr/chipdb-8k.bin
 
-VER = 0.1+$(shell test -e .git && echo `git log --oneline | wc -l`+`git diff --name-only HEAD | wc -l`)
+ARACHNE_VER = 0.1+$(shell test -e .git && echo `git log --oneline | wc -l`+`git diff --name-only HEAD | wc -l`)
 GIT_REV = $(shell git rev-parse --verify --short HEAD 2>/dev/null || echo UNKNOWN)
 
 VER_HASH = $(shell echo "$(ARACHNE_VER) $(GIT_REV)" | sum | cut -d ' ' -f -1)


### PR DESCRIPTION
This is a consequence of my old patch. Sorry for the inconvenience.
The merge got "VER" when the rest of the Makefile uses "ARCHNE_VER" to make it more arachne specific.