### PR TITLE
Fixed $_TBUF_ cases where the outputs are internally used

### DIFF
--- a/src/io.cc
+++ b/src/io.cc
@@ -27,25 +27,38 @@ instantiate_io(Design *d)
   Model *top = d->top();
   Model *io_model = d->find_model("SB_IO");
   Model *tbuf_model = d->find_model("$_TBUF_");
-  
+
+  // Validate all $_TBUF_ outputs
   for (Instance *inst : top->instances())
     {
       if (!models.is_tbuf(inst))
         continue;
-      
+
+      // Look for the $_TBUF_ output (Y)
       Port *p = inst->find_port("Y");
-      Port *q = p->connection_other_port();
-      if (!q
-          || !isa<Model>(q->node())
-          || (q->direction() != Direction::OUT
-              && q->direction() != Direction::INOUT))
-        fatal("$_TBUF_ gate must drive top-level output or inout port");
+      Net *n = p->connection();
+      if (!n)
+         fatal("Unconnected $_TBUF_ output");
+      // Its output must be connected to only one output port
+      // Additionally it could be connected to one or more inputs if the port is inout
+      unsigned found = 0;
+      for (Port *j : n->connections())
+         {
+          if (j != p &&
+              isa<Model>(j->node()) &&
+              (j->direction() == Direction::OUT || j->direction() == Direction::INOUT))
+             found++;
+         }
+      if (!found)
+         fatal("$_TBUF_ gate must drive top-level output or inout port");
+      if (found != 1)
+         fatal("$_TBUF_ gate must drive only one top-level output or inout port");
     }
-  
+
+  // Replace top-level ports using SB_IOs
   for (auto i : top->ports())
     {
       Port *p = i.second;
-      
       Port *q = p->connection_other_port();
       if (q
           && isa<Instance>(q->node())
@@ -53,8 +66,16 @@ instantiate_io(Design *d)
                && q->name() == "PACKAGE_PIN")
               || (models.is_pllX(cast<Instance>(q->node()))
                   && q->name() == "PACKAGEPIN")))
+        { // Already connected to an SB_IO or a PLL
         continue;
-      
+        }
+
+      // Now we need a net to connect the top-level port to the SB_IO output.
+      // The name of this net will be the name of the top-level port.
+
+      // If the net currently used (to connect $_TBUF_'s Y output to the top-level port)
+      // is already using this name, we rename the net to NAME$n (n is a number to avoid
+      // collisions).
 #ifndef NDEBUG
       bool matched = false;
 #endif
@@ -67,14 +88,18 @@ instantiate_io(Design *d)
 #endif
           top->rename_net(n, n->name());
         }
-      
+
+      // Connect the new net to the top-level port (disconnecting it from $_TBUF_)
       Net *t = top->add_net(p->name());
       assert(t);
       p->connect(t);
       assert(!matched || t->name() == p->name());
-      
+
+      // Now we create an SB_IO ...
       Instance *io_inst = top->add_instance(io_model);
+      // and connect its PACKAGE_PIN output to the new net
       io_inst->find_port("PACKAGE_PIN")->connect(t);
+      // The rest of the connection depends on the top-level port direction
       switch(p->direction())
         {
         case Direction::IN:
@@ -87,19 +112,37 @@ instantiate_io(Design *d)
         case Direction::OUT:
         case Direction::INOUT:
           {
+            // If the top-level port is connected to more than one internal port
+            // the connection_other_port will return NULL and we must figure out
+            // what's the $_TBUF_ output (Y)
+            if (!q && n && n->connections().size() > 1)
+              {
+               for (auto j : n->connections())
+                  {
+                   if (j != p && j->name() == "Y" && isa<Instance>(j->node()) &&
+                       cast<Instance>(j->node())->instance_of() == tbuf_model)
+                     {
+                      q = j; // $_TBUF_'s Y output
+                      break;
+                     }
+                  }
+              }
+            // Analyze the internal port connected to this top-level port
             if (q
                 && isa<Instance>(q->node())
                 && cast<Instance>(q->node())->instance_of() == tbuf_model
                 && q->name() == "Y")
-              {
+              { // Connected to a $_TBUF_'s Y output
                 Instance *tbuf = cast<Instance>(q->node());
-                
+
+                // Connect the $_TBUF_ nets to the SB_IO port
                 io_inst->find_port("D_OUT_0")->connect(tbuf->find_port("A")->connection());
                 io_inst->find_port("D_IN_0")->connect(tbuf->find_port("Y")->connection());
                 io_inst->find_port("OUTPUT_ENABLE")->connect(tbuf->find_port("E")->connection());
                 
                 io_inst->set_param("PIN_TYPE", BitVector(6, 0x29)); // 101001
-                
+
+                // Remove the $_TBUF_
                 tbuf->find_port("A")->disconnect();
                 tbuf->find_port("E")->disconnect();
                 tbuf->find_port("Y")->disconnect();
@@ -108,6 +151,7 @@ instantiate_io(Design *d)
               }
             else
               {
+                // This top-level port is an output, not connected to a $_TBUF_
                 if (p->direction() == Direction::INOUT)
                   fatal(fmt("bidirectional port `" << p->name()
                             << "' must be driven by tri-state buffer"));


### PR DESCRIPTION
Currently the code assumes that $_TBUF_ output (Y) is connected to just one point: a top-level port.
The problem is that when we use inout pins Y is connected to the top-level port AND internal logic using the top-level port as input.
In this case the number of connections for the net that connects the $_TBUF_ to the outside world is more than 2 and connection_other_port returns NULL. In this case arachne aborts saying the $_TBUF_ must be connected to an output or inout port.
This patch allows more than 2 connections and selects the proper connection to use.
I verified it in a design with 17 $_TBUF_ used in 2 different ways.
The patch passed the regression tests.
It look bigger than what it really is because I added some comments about what the code is doing.