### PR TITLE
Better emscripten support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.d
 *~
 *.o
+*.host-o
 /bin/arachne-pnr
+/bin/arachne-pnr-host
 /bin/arachne-pnr.exe
 /tests/test_bv
 /tests/test_us

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ mxebin:
 .PHONY: install
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp bin/arachne-pnr $(DESTDIR)$(PREFIX)/bin/arachne-pnr
+	cp bin/arachne-pnr $(DESTDIR)$(PREFIX)/bin/arachne-pnr$(EXE)
 	mkdir -p $(DESTDIR)$(PREFIX)/share/arachne-pnr
 	cp share/arachne-pnr/chipdb-384.bin $(DESTDIR)$(PREFIX)/share/arachne-pnr/chipdb-384.bin
 	cp share/arachne-pnr/chipdb-1k.bin $(DESTDIR)$(PREFIX)/share/arachne-pnr/chipdb-1k.bin
@@ -144,8 +144,8 @@ install: all
 
 .PHONY: uninstall
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/arachne-pnr
-	rm -f $(DESTDIR)$(PREFIX)/bin/share/arachne-pnr/*.bin
+	rm -f $(DESTDIR)$(PREFIX)/bin/arachne-pnr$(EXE)
+	rm -f $(DESTDIR)$(PREFIX)/share/arachne-pnr/*.bin
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -163,3 +163,8 @@ clean:
 	rm -rf tests/fsm/temp tests/fsm/1k tests/fsm/8k
 	rm -rf tests/regression/1k tests/regression/8k
 	rm -rf tests/simple/txt.sum tests/simple/1k tests/simple/8k
+
+.PHONY: emcc
+emcc:
+	$(MAKE) EXE=.js clean
+	$(MAKE) CC=emcc CXX=emcc HOST_CC=gcc HOST_CXX=g++ PREFIX=/ LDFLAGS="--memory-init-file 0 --embed-file share -s TOTAL_MEMORY=256*1024*1024" EXE=.js

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifneq ($(CXX),$(HOST_CXX))
 endif
 
 .PHONY: all
-all: bin/arachne-pnr share/arachne-pnr/chipdb-384.bin share/arachne-pnr/chipdb-1k.bin share/arachne-pnr/chipdb-8k.bin
+all: bin/arachne-pnr$(EXE) share/arachne-pnr/chipdb-384.bin share/arachne-pnr/chipdb-1k.bin share/arachne-pnr/chipdb-8k.bin
 
 ARACHNE_VER = 0.1+$(shell test -e .git && echo `git log --oneline | wc -l`+`git diff --name-only HEAD | wc -l`)
 GIT_REV = $(shell git rev-parse --verify --short HEAD 2>/dev/null || echo UNKNOWN)
@@ -42,19 +42,24 @@ VER_HASH = $(shell echo "$(ARACHNE_VER) $(GIT_REV)" | sum | cut -d ' ' -f -1)
 src/version_$(VER_HASH).cc:
 	echo "const char *version_str = \"arachne-pnr $(ARACHNE_VER) (git sha1 $(GIT_REV), $(notdir $(CXX)) `$(CXX) --version | tr ' ()' '\n' | grep '^[0-9]' | head -n1` $(filter -f% -m% -O% -DNDEBUG,$(CXXFLAGS)))\";" > src/version_$(VER_HASH).cc
 
-bin/arachne-pnr: src/arachne-pnr.o src/netlist.o src/blif.o src/pack.o src/place.o src/util.o src/io.o src/route.o src/chipdb.o src/location.o src/configuration.o src/line_parser.o src/pcf.o src/global.o src/constant.o src/designstate.o src/version_$(VER_HASH).o
+bin/arachne-pnr$(EXE): src/arachne-pnr.o src/netlist.o src/blif.o src/pack.o src/place.o src/util.o src/io.o src/route.o src/chipdb.o src/location.o src/configuration.o src/line_parser.o src/pcf.o src/global.o src/constant.o src/designstate.o src/version_$(VER_HASH).o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 ifeq ($(IS_CROSS_COMPILING),yes)
 bin/arachne-pnr-host: src/arachne-pnr.host-o src/netlist.host-o src/blif.host-o src/pack.host-o src/place.host-o src/util.host-o src/io.host-o src/route.host-o src/chipdb.host-o src/location.host-o src/configuration.host-o src/line_parser.host-o src/pcf.host-o src/global.host-o src/constant.host-o src/designstate.host-o src/version_$(VER_HASH).host-o
 	$(HOST_CXX) $(HOST_CXXFLAGS) $(HOST_LDFLAGS) -o $@ $^ $(HOST_LIBS)
 else
-bin/arachne-pnr-host: bin/arachne-pnr
+bin/arachne-pnr-host: bin/arachne-pnr$(EXE)
 	cp $< $@
 endif
 
 %.host-o: %.cc
 	$(HOST_CXX) -c $(HOST_CPPFLAGS) $(HOST_CXXFLAGS) -o $@ $<
+
+ifeq ($(EXE),.js)
+# Special hack to make sure chipdb is built first
+bin/arachne-pnr$(EXE): | share/arachne-pnr/chipdb-384.bin share/arachne-pnr/chipdb-1k.bin share/arachne-pnr/chipdb-8k.bin
+endif
 
 share/arachne-pnr/chipdb-384.bin: bin/arachne-pnr-host $(ICEBOX)/chipdb-384.txt
 	mkdir -p share/arachne-pnr
@@ -136,7 +141,7 @@ mxebin:
 .PHONY: install
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp bin/arachne-pnr $(DESTDIR)$(PREFIX)/bin/arachne-pnr$(EXE)
+	cp bin/arachne-pnr$(EXE) $(DESTDIR)$(PREFIX)/bin/arachne-pnr$(EXE)
 	mkdir -p $(DESTDIR)$(PREFIX)/share/arachne-pnr
 	cp share/arachne-pnr/chipdb-384.bin $(DESTDIR)$(PREFIX)/share/arachne-pnr/chipdb-384.bin
 	cp share/arachne-pnr/chipdb-1k.bin $(DESTDIR)$(PREFIX)/share/arachne-pnr/chipdb-1k.bin
@@ -149,7 +154,7 @@ uninstall:
 
 .PHONY: clean
 clean:
-	rm -f src/*.o src/*.host-o tests/*.o src/*.d tests/*.d bin/arachne-pnr bin/arachne-pnr-host
+	rm -f src/*.o src/*.host-o tests/*.o src/*.d tests/*.d bin/arachne-pnr$(EXE) bin/arachne-pnr-host
 	rm -f tests/test_bv tests/test_us
 	rm -f share/arachne-pnr/*.bin
 	rm -f src/version_*

--- a/src/arachne-pnr.cc
+++ b/src/arachne-pnr.cc
@@ -34,6 +34,10 @@
 #include <cstring>
 #include <cstdlib>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 const char *program_name;
 
 class null_streambuf : public std::streambuf
@@ -128,6 +132,16 @@ struct null_ostream : public std::ostream
 int
 main(int argc, const char **argv)
 {
+#ifdef __EMSCRIPTEN__
+  EM_ASM(
+    if (ENVIRONMENT_IS_NODE)
+    {
+      FS.mkdir('/x');
+      FS.mount(NODEFS, { root: '.' }, '/x');
+    }
+  );
+#endif
+
   program_name = argv[0];
   
   bool help = false,

--- a/src/util.cc
+++ b/src/util.cc
@@ -163,6 +163,12 @@ std::string proc_self_dirname()
                 path += char(shortpath[i]);
         return path;
 }
+#elif defined(__EMSCRIPTEN__)
+std::string proc_self_dirname()
+{
+        // This is a fake path, but ../ will always be appended and this will still work.
+        return "/bin/";
+}
 #else
         #error Dont know how to determine process executable base path!
 #endif


### PR DESCRIPTION
This depends on my previous #73 PR.

The last commit modifies arachne-pnr to mount emscripten's NODEFS on `/x` if the resulting javascript is run under nodejs. This is useful for testing so that the resulting javascript can interact with files on the host filesystem. By default, emscripten-compiled output can only access its in-memory virtual filesystem. It also isn't possible to mount additional emscripten filesystems over the root, so as a compromise NODEFS is mounted on `/x`. After this change, it is possible to run commands like
```
$ nodejs ./bin/arachne-pnr.js -d 8k /x/tests/simple/carry.blif -o /x/carry.asc
```
This will create a `carry.asc` in the current working directory.