### PR TITLE
Notify user if not able to use specific pin for global buffer output

### DIFF
--- a/src/global.cc
+++ b/src/global.cc
@@ -239,7 +239,10 @@ Promoter::promote(bool do_promote)
           Port *out = inst->find_port("GLOBAL_BUFFER_OUTPUT");
           if (out->connected())
             {
-              int g = chipdb->loc_pin_glb_num.at(chipdb->cell_location[c]);
+              auto loc = chipdb->cell_location[c];
+              if (chipdb->loc_pin_glb_num.find(loc) == chipdb->loc_pin_glb_num.end())
+                fatal(fmt("Not able to use pin " << ds.package.loc_pin.at(loc) << " for global buffer output"));
+              int g = chipdb->loc_pin_glb_num.at(loc);
               for (uint8_t gc : global_classes)
                 {
                   if (gc & (1 << g))


### PR DESCRIPTION
This helps detecting problems related to issue #81