### PR TITLE
Minor UltraPlus Improvements

### DIFF
--- a/src/global.cc
+++ b/src/global.cc
@@ -517,7 +517,6 @@ Promoter::promote(bool do_promote)
             if ((gc2 & gc) == gc)
               ++gc_used[gc2];
           }
-        
         *logs << "  promoted " << n->name()
               << ", " << n_conn_promoted << " / " << n_conn << "\n";
       }

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -1312,6 +1312,14 @@ Design::create_standard_models()
   hfosc->add_port("CLKHF", Direction::OUT);
   hfosc->set_param("CLKHF_DIV", "0b00");
   
+  Model *hfosc_trim = new Model(this, "SB_HFOSC_TRIM");
+  hfosc_trim->add_port("CLKHFPU", Direction::IN, Value::ZERO);
+  hfosc_trim->add_port("CLKHFEN", Direction::IN, Value::ZERO);
+  for(int i = 0; i < 10; i++)
+    hfosc_trim->add_port("TRIM" + std::to_string(i), Direction::IN, Value::ZERO);
+  hfosc_trim->add_port("CLKHF", Direction::OUT);
+  hfosc_trim->set_param("CLKHF_DIV", "0b00");
+  
   Model *lfosc = new Model(this, "SB_LFOSC");
   lfosc->add_port("CLKLFPU", Direction::IN, Value::ZERO);
   lfosc->add_port("CLKLFEN", Direction::IN, Value::ZERO);

--- a/src/netlist.hh
+++ b/src/netlist.hh
@@ -477,7 +477,9 @@ public:
   }
   bool is_mac16(const Instance *inst) const {return inst->instance_of()->name() == "SB_MAC16";}
   bool is_spram(const Instance *inst) const {return inst->instance_of()->name() == "SB_SPRAM256KA";}
-  bool is_hfosc(const Instance *inst) const {return inst->instance_of()->name() == "SB_HFOSC";}
+  bool is_hfosc(const Instance *inst) const {return inst->instance_of()->name() == "SB_HFOSC" || inst->instance_of()->name() == "SB_HFOSC_TRIM";}
+  bool is_hfosc_trim(const Instance *inst) const {return inst->instance_of()->name() == "SB_HFOSC_TRIM";}
+
   bool is_lfosc(const Instance *inst) const {return inst->instance_of()->name() == "SB_LFOSC";}
   bool is_rgba_drv(const Instance *inst) const {return inst->instance_of()->name() == "SB_RGBA_DRV";}
   bool is_ledda_ip(const Instance *inst) const {return inst->instance_of()->name() == "SB_LEDDA_IP";}

--- a/src/place.cc
+++ b/src/place.cc
@@ -1518,7 +1518,16 @@ Placer::configure()
         }
         
         continue; 
-      } else if(models.is_spi(inst) || models.is_ledda_ip(inst)) {
+      } else if(models.is_spi(inst)) {
+        placement[inst] = cell;
+        for(auto bits : chipdb->cell_mfvs.at(cell)) {
+          if(startswith(bits.first, "SPI_ENABLE_")) {
+            CBit spien_cb = chipdb->extra_cell_cbit(cell, bits.first, true);
+            conf.set_cbit(spien_cb, true);
+          }
+        }
+        continue;
+      } else if(models.is_ledda_ip(inst)) {
         placement[inst] = cell;
         continue;
       }

--- a/src/place.cc
+++ b/src/place.cc
@@ -1485,6 +1485,11 @@ Placer::configure()
           const auto &ecb = chipdb->extra_bits.at(fmt("padin_glb_netwk." << driven_glb));
           conf.set_extra_cbit(ecb);
         }
+        
+        if(models.is_hfosc_trim(inst)) {
+          CBit trimen_cb = chipdb->extra_cell_cbit(cell, "TRIM_EN");
+          conf.set_cbit(trimen_cb, true);
+        }
         continue;      
       } else if(models.is_lfosc(inst)) {
         placement[inst] = cell;

--- a/src/place.cc
+++ b/src/place.cc
@@ -994,6 +994,14 @@ Placer::Placer(random_generator &rg_, DesignState &ds_)
           for (int t2 : t_related)
             related_tiles[t2] = t_related;
         }
+      else if(chipdb->cell_type[i] == CellType::HFOSC)
+        {
+          global_cells[chipdb->get_oscillator_glb(i, "CLKHF")].push_back(i);
+        }
+      else if(chipdb->cell_type[i] == CellType::LFOSC)
+        {
+          global_cells[chipdb->get_oscillator_glb(i, "CLKLF")].push_back(i);
+        }
     }
   
   for (int i = 0; i < chipdb->width; ++i)
@@ -1079,6 +1087,18 @@ Placer::Placer(random_generator &rg_, DesignState &ds_)
         {
           Net *n = inst->find_port("GLOBAL_BUFFER_OUTPUT")->connection();
           if (n)
+            net_global[net_idx.at(n)] = true;
+        }
+      else if (models.is_hfosc(inst))
+        {
+          Net *n = inst->find_port("CLKHF")->connection();
+          if (n && !inst->is_attr_set("ROUTE_THROUGH_FABRIC"))
+            net_global[net_idx.at(n)] = true;
+        }
+      else if (models.is_lfosc(inst))
+        {
+          Net *n = inst->find_port("CLKLF")->connection();
+          if (n && !inst->is_attr_set("ROUTE_THROUGH_FABRIC"))
             net_global[net_idx.at(n)] = true;
         }
     }


### PR DESCRIPTION
This contains a few small UltraPlus changes:
 - Set the SPI enable bits correctly
 - Support trimming of the HFOSC (an undocumented feature), using the SB_HFOSC_TRIM primitive
 - Fix a bug where the oscillator output could collide with another global buffer (thanks to Nikolaj for finding and reporting this one)