### PR TITLE
Ignore ACCUMCI and SIGNEXTIN when tied to 0

### DIFF
--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -1283,8 +1283,8 @@ Design::create_standard_models()
   mac16->add_port("OHOLDTOP", Direction::IN, Value::ZERO);
   mac16->add_port("OHOLDBOT", Direction::IN, Value::ZERO); 
   mac16->add_port("CI", Direction::IN, Value::ZERO);
-  mac16->add_port("ACCUMCI", Direction::IN);
-  mac16->add_port("SIGNEXTIN", Direction::IN);
+  mac16->add_port("ACCUMCI", Direction::IN, Value::ZERO);
+  mac16->add_port("SIGNEXTIN", Direction::IN, Value::ZERO);
 
   for(int i = 0; i < 32; i++)
     mac16->add_port("O[" + std::to_string(i) + "]", Direction::OUT);

--- a/src/route.cc
+++ b/src/route.cc
@@ -242,7 +242,14 @@ Router::port_cnet(Instance *inst, Port *p)
             db_name += c;
         }          
       }
-
+      
+      if(models.is_mac16(inst)) {
+        if(p_name == "ACCUMCI" || p_name == "SIGNEXTIN") {
+          assert(p->connection()->is_constant() && (p->connection()->constant() == Value::ZERO));
+          return -1;
+        }
+      }
+      
       const auto &p2 = chipdb->cell_mfvs.at(cell).at(db_name);
       t = p2.first;
       tile_net_name = p2.second;


### PR DESCRIPTION
Some of Lattice's example code ties ACCUMCI and SIGNEXTIN of the SB_MAC16s to 0, instead of leaving them unconnected. Functionally this is equivalent, but arachne-pnr doesn't have find pins in the chipdb, because they're for cascading, so was failing. This PR ignores them when they're at constant 0, which is the correct behaviour.

In the future a proper implementation of DSP cascading will need to be done, placing DSPs in a chain similar to LUT carry connections based on the connections of these pins. 