### PR TITLE
Fix handling of LOCKED attribute on extra cells, if not available in a certain package

### DIFF
--- a/src/bstream.hh
+++ b/src/bstream.hh
@@ -340,7 +340,7 @@ operator>>(ibstream &ibs, std::vector<T> &v)
 }
 
 template<class T> ibstream &
-operator<<(ibstream &ibs, std::set<T> &s)
+operator>>(ibstream &ibs, std::set<T> &s)
 {
   s.clear();
   size_t n;

--- a/src/chipdb.cc
+++ b/src/chipdb.cc
@@ -795,6 +795,7 @@ ChipDBParser::parse_cmd_extra_cell()
     fatal(fmt("unknown extra cell type `" << cell_type << "'"));
   
   std::map<std::string, std::pair<int, std::string>> mfvs;
+  std::set<std::string> locked_pkgs;
   for (;;)
     {
       read_line();
@@ -802,11 +803,16 @@ ChipDBParser::parse_cmd_extra_cell()
           || line[0] == '.')
         {
           extend(chipdb->cell_mfvs, c, mfvs);
+          extend(chipdb->cell_locked_pkgs, c, locked_pkgs);
           return;
         }
 
-      if (words.size() > 0 && words[0] == "LOCKED")
+      if (words.size() > 0 && words[0] == "LOCKED") {
+        for (size_t i = 1; i < words.size(); i++)
+          extend(locked_pkgs, words[i]);
         continue;
+      }
+
       
       if (words.size() != 4)
         fatal("invalid .extra_cell entry");
@@ -1017,6 +1023,7 @@ ChipDB::bwrite(obstream &obs) const
       << cell_type
       << cell_location
       << cell_mfvs
+      << cell_locked_pkgs
       << cell_type_cells
     // bank_cells
       << switches
@@ -1052,6 +1059,7 @@ ChipDB::bread(ibstream &ibs)
       >> cell_type
       >> cell_location
       >> cell_mfvs
+      >> cell_locked_pkgs
       >> cell_type_cells
     // bank_cells
       >> switches

--- a/src/chipdb.hh
+++ b/src/chipdb.hh
@@ -256,6 +256,7 @@ public:
   BasedVector<Location, 1> cell_location;
   std::map<int, std::map<std::string, std::pair<int, std::string>>>
     cell_mfvs;
+  std::map<int, std::set<std::string>> cell_locked_pkgs;
   
   std::vector<std::vector<int>> tile_pos_cell;
   int loc_cell(const Location &loc) const 

--- a/src/pack.cc
+++ b/src/pack.cc
@@ -53,6 +53,8 @@ class Packer
   void pack_carries_from(Instance *f);
   void pack_carries();
   
+  int count_extra_cells(CellType ct);
+  
 public:
   Packer(DesignState &ds);
   
@@ -621,6 +623,18 @@ Packer::pack_carries()
     }
 }
 
+int
+Packer::count_extra_cells(CellType ct)
+{
+  int n = 0;
+  for (auto cell : chipdb->cell_type_cells[cell_type_idx(ct)]) {
+    if (!contains(chipdb->cell_locked_pkgs.at(cell), package.name))
+      n++;
+  }
+  return n;
+}
+
+
 void
 Packer::pack()
 {
@@ -737,23 +751,23 @@ Packer::pack()
           << "BRAMs        " << n_bram << " / " << n_ramt_tiles << "\n"
           << "WARMBOOTs    " << n_warmboot << " / " << n_warmboot_cells << "\n"
           << "PLLs         " << n_pll << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::PLL)].size() << "\n"
+          << count_extra_cells(CellType::PLL) << "\n"
           << "MAC16s       " << n_mac16 << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::MAC16)].size() << "\n"
+          << count_extra_cells(CellType::MAC16) << "\n"
           << "SPRAM256KAs  " << n_spram << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::SPRAM)].size() << "\n"
+          << count_extra_cells(CellType::SPRAM) << "\n"
           << "HFOSCs       " << n_hfosc << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::HFOSC)].size() << "\n"
+          << count_extra_cells(CellType::HFOSC) << "\n"
           << "LFOSCs       " << n_lfosc << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::LFOSC)].size() << "\n"
+          << count_extra_cells(CellType::LFOSC) << "\n"
           << "RGBA_DRVs    " << n_rgba_drv << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::RGBA_DRV)].size() << "\n"
+          << count_extra_cells(CellType::RGBA_DRV) << "\n"
           << "LEDDA_IPs    " << n_ledda_ip << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::LEDDA_IP)].size() << "\n"
+          << count_extra_cells(CellType::LEDDA_IP) << "\n"
           << "I2Cs         " << n_i2c << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::I2C_IP)].size() << "\n"
+          << count_extra_cells(CellType::I2C_IP) << "\n"
           << "SPIs         " << n_spi << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::SPI_IP)].size() << "\n\n";
+          << count_extra_cells(CellType::SPI_IP) << "\n\n";
   } else {
     *logs << "\nAfter packing:\n"
           << "IOs          " << n_io << " / " << package.pin_loc.size() << "\n"
@@ -768,7 +782,7 @@ Packer::pack()
           << "BRAMs        " << n_bram << " / " << n_ramt_tiles << "\n"
           << "WARMBOOTs    " << n_warmboot << " / " << n_warmboot_cells << "\n"
           << "PLLs         " << n_pll << " / " 
-          << chipdb->cell_type_cells[cell_type_idx(CellType::PLL)].size() << "\n\n";
+          << count_extra_cells(CellType::PLL) << "\n\n";
   }
   
 }

--- a/src/pcf.cc
+++ b/src/pcf.cc
@@ -306,7 +306,8 @@ ConstraintsPlacer::place()
           
           c = chipdb->loc_cell(pll_loc);
           if (!c
-              || chipdb->cell_type[c] != CellType::PLL)
+              || chipdb->cell_type[c] != CellType::PLL
+              || contains(chipdb->cell_locked_pkgs.at(c), ds.package.name))
             fatal(fmt("bad constraint on `"
                       << p.first << "': no PLL at pin "
                       << ds.package.loc_pin.at(loc)));
@@ -362,7 +363,8 @@ ConstraintsPlacer::place()
             {
               if (cell_gate[c])
                 continue;
-              
+              if (contains(chipdb->cell_locked_pkgs.at(c), ds.package.name))
+                continue;
               good = true;
               for (int io_cell : ds.pll_out_io_cells(inst, c))
                 {
@@ -388,10 +390,15 @@ ConstraintsPlacer::place()
                   break;
                 }
             }
+          int n_pkg_pll = 0;
+          for (auto cell : chipdb->cell_type_cells[cell_type_idx(CellType::PLL)]) {
+            if (!contains(chipdb->cell_locked_pkgs.at(cell), ds.package.name))
+              n_pkg_pll++;
+          }
           if (!good)
             fatal(fmt("failed to place: placed " << n_pll_placed
                       << " PLLs of " << n_pll
-                      << " / " << chipdb->cell_type_cells[cell_type_idx(CellType::PLL)].size()));
+                      << " / " << n_pkg_pll));
         }
     }
 }

--- a/src/place.cc
+++ b/src/place.cc
@@ -674,6 +674,9 @@ Placer::valid(int t)
       Instance *inst3 = g3 ? gates[g3] : nullptr;
       if (inst3)
         {
+          if (contains(chipdb->cell_locked_pkgs.at(cell3), package.name))
+            return false;
+          
           Port *pa = inst3->find_port("PLLOUTGLOBAL");
           if (!pa)
             pa = inst3->find_port("PLLOUTGLOBALA");


### PR DESCRIPTION
Some packages of the 1k and 8k have fewer PLLs than others, due to the VccPLL/GNDPLL not being bonded out. icestorm signifies this in the chipdb using the `LOCKED` entry followed by a list of packages where the cell isn't available, but until now arachne-pnr was ignoring this.

NB: because of modifications to the chipdb parsing, binary chipdbs will need to be rebuilt after this PR is merged (this should be automatic if using the normal Makefile).