### PR TITLE
Enable building on FreeBSD

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -133,6 +133,18 @@ std::string proc_self_dirname()
                 buflen--;
         return std::string(path, buflen);
 }
+#elif defined(__FreeBSD__)
+std::string proc_self_dirname()
+{
+        char path[PATH_MAX];
+        ssize_t buflen = readlink("/proc/curproc/file", path, sizeof(path));
+        if (buflen < 0) {
+                fatal(fmt("readlink(\"/proc/curproc/file\") failed: " << strerror(errno)));
+        }
+        while (buflen > 0 && path[buflen-1] != '/')
+                buflen--;
+        return std::string(path, buflen);
+}
 #elif defined(__APPLE__)
 std::string proc_self_dirname()
 {


### PR DESCRIPTION
This patch enables arachne-pnr to build under FreeBSD OS.
FreeBSD uses <code>/proc/curproc/file</code> instead of <code>/proc/self/exe</code>.