### PR TITLE
Include associated headers first

### DIFF
--- a/src/chipdb.cc
+++ b/src/chipdb.cc
@@ -13,8 +13,8 @@
    You should have received a copy of the GNU General Public License
    along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "util.hh"
 #include "chipdb.hh"
+#include "util.hh"
 #include "line_parser.hh"
 
 #include <cassert>

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -13,8 +13,8 @@
    You should have received a copy of the GNU General Public License
    along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "chipdb.hh"
 #include "configuration.hh"
+#include "chipdb.hh"
 #include "util.hh"
 #include "netlist.hh"
 

--- a/src/constant.cc
+++ b/src/constant.cc
@@ -13,8 +13,8 @@
    You should have received a copy of the GNU General Public License
    along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "netlist.hh"
 #include "constant.hh"
+#include "netlist.hh"
 #include "chipdb.hh"
 
 #include <cassert>

--- a/src/io.cc
+++ b/src/io.cc
@@ -13,8 +13,8 @@
    You should have received a copy of the GNU General Public License
    along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "netlist.hh"
 #include "io.hh"
+#include "netlist.hh"
 #include "casting.hh"
 
 #include <cassert>

--- a/src/line_parser.cc
+++ b/src/line_parser.cc
@@ -13,8 +13,8 @@
    You should have received a copy of the GNU General Public License
    along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "util.hh"
 #include "line_parser.hh"
+#include "util.hh"
 
 std::ostream &
 operator<<(std::ostream &s, const LexicalPosition &lp)

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -13,8 +13,8 @@
    You should have received a copy of the GNU General Public License
    along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "util.hh"
 #include "netlist.hh"
+#include "util.hh"
 #include "casting.hh"
 
 #include <cassert>


### PR DESCRIPTION
This prevents missing dependencies in the header files.