### PR TITLE
Allow Unix directory structure for arachne paths on Windows for msys2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ mxebin:
 	mv share/arachne-pnr/chipdb-8k.bin arachne-pnr-win32/
 	mv share/arachne-pnr/chipdb-5k.bin arachne-pnr-win32/
 	$(MAKE) clean
-	$(MAKE) CC=/usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc CXX=/usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-g++ bin/arachne-pnr
+	$(MAKE) CC=/usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc CXX=/usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-g++ CXXFLAGS="$(CXXFLAGS) -DMXE_DIR_STRUCTURE" bin/arachne-pnr
 	mv bin/arachne-pnr arachne-pnr-win32/arachne-pnr.exe
 	zip -r arachne-pnr-win32.zip arachne-pnr-win32/
 	rm -rf arachne-pnr-win32

--- a/src/arachne-pnr.cc
+++ b/src/arachne-pnr.cc
@@ -1,15 +1,15 @@
 /* Copyright (C) 2015 Cotton Seed
-   
+
    This file is part of arachne-pnr.  Arachne-pnr is free software;
    you can redistribute it and/or modify it under the terms of the GNU
    General Public License version 2 as published by the Free Software
    Foundation.
-   
+
    This program is distributed in the hope that it will be useful, but
    WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
    General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
@@ -43,13 +43,13 @@ const char *program_name;
 class null_streambuf : public std::streambuf
 {
 public:
-  int overflow(int c) override { return c; }  
+  int overflow(int c) override { return c; }
 };
 
 void
 usage()
 {
-  std::cout 
+  std::cout
     << "Usage:\n"
     << "\n"
     << "  " << program_name << " [options] [input-file]\n"
@@ -143,7 +143,7 @@ main(int argc, const char **argv)
 #endif
 
   program_name = argv[0];
-  
+
   bool help = false,
     quiet = false,
     do_promote_globals = true,
@@ -162,7 +162,7 @@ main(int argc, const char **argv)
     *seed_str = nullptr,
     *max_passes_str = nullptr,
     *binary_chipdb = nullptr;
-  
+
   for (int i = 1; i < argc; ++i)
     {
       if (argv[i][0] == '-')
@@ -178,7 +178,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               device = argv[i];
             }
@@ -187,7 +187,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               chipdb_file = argv[i];
             }
@@ -195,7 +195,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               binary_chipdb = argv[i];
             }
@@ -207,7 +207,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               pack_blif = argv[i];
             }
@@ -216,7 +216,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               pack_verilog = argv[i];
             }
@@ -224,7 +224,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               place_blif = argv[i];
             }
@@ -235,7 +235,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               pcf_file = argv[i];
             }
@@ -244,7 +244,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               package_name_cp = argv[i];
             }
@@ -255,7 +255,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               post_place_pcf = argv[i];
             }
@@ -264,7 +264,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               seed_str = argv[i];
             }
@@ -273,7 +273,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               max_passes_str = argv[i];
             }
@@ -282,7 +282,7 @@ main(int argc, const char **argv)
             {
               if (i + 1 >= argc)
                 fatal(fmt(argv[i] << ": expected argument"));
-              
+
               ++i;
               output_file = argv[i];
             }
@@ -303,19 +303,19 @@ main(int argc, const char **argv)
             input_file = argv[i];
         }
     }
-  
+
   if (help)
     {
       usage();
       exit(EXIT_SUCCESS);
     }
-  
+
   if (device != "384"
       && device != "1k"
       && device != "5k"
       && device != "8k")
     fatal(fmt("unknown device: " << device));
-  
+
   std::string package_name;
   if (package_name_cp)
     package_name = package_name_cp;
@@ -330,28 +330,28 @@ main(int argc, const char **argv)
       assert(device == "8k");
       package_name = "ct256";
     }
-  
+
   std::ostream *null_ostream = nullptr;
   if (quiet)
     logs = null_ostream = new std::ostream(new null_streambuf);
   else
     logs = &std::cerr;
-  
+
   unsigned seed = 0;
   if (seed_str)
     {
       std::string seed_s = seed_str;
-      
+
       if (seed_s.empty())
         fatal("invalid empty seed");
-      
+
       for (char ch : seed_s)
         {
           if (ch >= '0'
               && ch <= '9')
             seed = seed * 10 + (unsigned)(ch - '0');
           else
-            fatal(fmt("invalid character `" 
+            fatal(fmt("invalid character `"
                       << ch
                       << "' in unsigned integer literal in seed"));
         }
@@ -363,24 +363,24 @@ main(int argc, const char **argv)
   if (max_passes_str)
     {
       std::string max_passes_s = max_passes_str;
-      
+
       if (max_passes_s.empty())
         fatal("invalid empty max-passes value");
-      
+
       for (char ch : max_passes_s)
         {
           if (ch >= '0'
               && ch <= '9')
             max_passes = max_passes * 10 + (unsigned)(ch - '0');
           else
-            fatal(fmt("invalid character `" 
+            fatal(fmt("invalid character `"
                       << ch
                       << "' in unsigned integer literal in max-passes value"));
         }
     }
   else
     max_passes = 200;
-  
+
   if (randomize_seed)
     {
       std::random_device rd;
@@ -388,34 +388,34 @@ main(int argc, const char **argv)
         seed = rd();
       } while (seed == 0);
     }
-  
+
   *logs << "seed: " << seed << "\n";
   if (!seed)
     fatal("zero seed");
-  
+
   random_generator rg(seed);
-  
+
   *logs << "device: " << device << "\n";
   std::string chipdb_file_s;
   if (chipdb_file)
     chipdb_file_s = chipdb_file;
   else
-#ifdef _WIN32
+#if defined(_WIN32) && defined(MXE_DIR_STRUCTURE)
     chipdb_file_s = (std::string("+/chipdb-")
                      + device
                      + ".bin");
 #else
     chipdb_file_s = (std::string("+/share/arachne-pnr/chipdb-")
-                     + device 
+                     + device
                      + ".bin");
 #endif
   *logs << "read_chipdb " << chipdb_file_s << "...\n";
   const ChipDB *chipdb = read_chipdb(chipdb_file_s);
-  
+
   if (binary_chipdb)
     {
       *logs << "write_binary_chipdb " << binary_chipdb << "\n";
-      
+
       std::string expanded = expand_filename(binary_chipdb);
       std::ofstream ofs(expanded, std::ofstream::out | std::ofstream::binary);
       if (ofs.fail())
@@ -423,21 +423,21 @@ main(int argc, const char **argv)
                   << strerror(errno)));
       obstream obs(ofs);
       chipdb->bwrite(obs);
-      
+
       // clean up
       if (chipdb)
         delete chipdb;
-      
+
       logs = nullptr;
       if (null_ostream)
         {
           delete null_ostream;
           null_ostream = nullptr;
         }
-      
+
       return 0;
     }
-  
+
   *logs << "  supported packages: ";
   bool first = true;
   for (const auto &p : chipdb->packages)
@@ -449,22 +449,22 @@ main(int argc, const char **argv)
       *logs << p.first;
     }
   *logs << "\n";
-  
+
   // chipdb->dump(std::cout);
-  
+
   auto package_i = chipdb->packages.find(package_name);
   if (package_i == chipdb->packages.end())
     fatal(fmt("unknown package `" << package_name << "'"));
   const Package &package = package_i->second;
-  
+
 #ifdef __AFL_HAVE_MANUAL_CONTROL
   __AFL_INIT();
 #endif
-  
+
   /*
   while (__AFL_LOOP(1000)) {
   */
-  
+
   Design *d;
   if (input_file)
     {
@@ -477,17 +477,17 @@ main(int argc, const char **argv)
       d = read_blif("<stdin>", std::cin);
     }
   // d->dump();
-  
+
   *logs << "prune...\n";
   d->prune();
 #ifndef NDEBUG
   d->check();
 #endif
   // d->dump();
-  
+
   {
     DesignState ds(chipdb, package, d);
-    
+
     if (route_only)
       {
         for (Instance *inst : ds.top->instances())
@@ -506,21 +506,21 @@ main(int argc, const char **argv)
             *logs << "read_pcf " << pcf_file << "...\n";
             read_pcf(pcf_file, ds);
           }
-        
+
         *logs << "instantiate_io...\n";
         instantiate_io(d);
 #ifndef NDEBUG
         d->check();
 #endif
         // d->dump();
-        
+
         *logs << "pack...\n";
         pack(ds);
 #ifndef NDEBUG
         d->check();
 #endif
         // d->dump();
-        
+
         if (pack_blif)
           {
             *logs << "write_blif " << pack_blif << "\n";
@@ -543,28 +543,28 @@ main(int argc, const char **argv)
             fs << "/* " << version_str << " */\n";
             d->write_verilog(fs);
           }
-        
+
         *logs << "place_constraints...\n";
         place_constraints(ds);
 #ifndef NDEBUG
         d->check();
 #endif
-        
+
         // d->dump();
-        
+
         *logs << "promote_globals...\n";
         promote_globals(ds, do_promote_globals);
 #ifndef NDEBUG
         d->check();
 #endif
         // d->dump();
-        
+
         *logs << "realize_constants...\n";
         realize_constants(chipdb, d);
 #ifndef NDEBUG
         d->check();
 #endif
-	
+
         *logs << "place...\n";
         // d->dump();
         place(rg, ds);
@@ -572,7 +572,7 @@ main(int argc, const char **argv)
         d->check();
 #endif
         // d->dump();
-        
+
         if (post_place_pcf)
           {
             *logs << "write_pcf " << post_place_pcf << "...\n";
@@ -593,12 +593,12 @@ main(int argc, const char **argv)
                                       ->connection_other_port());
                     assert(isa<Model>(top_port->node())
                            && cast<Model>(top_port->node()) == ds.top);
-                    
+
                     fs << "set_io " << top_port->name() << " " << pin << "\n";
                   }
               }
           }
-        
+
         if (place_blif)
           {
             for (const auto &p : ds.placement)
@@ -612,7 +612,7 @@ main(int argc, const char **argv)
                                       << "," << chipdb->tile_y(t)
                                       << "/" << pos));
               }
-            
+
             *logs << "write_blif " << place_blif << "\n";
             std::string expanded = expand_filename(place_blif);
             std::ofstream fs(expanded);
@@ -623,15 +623,15 @@ main(int argc, const char **argv)
             d->write_blif(fs);
           }
       }
-    
+
     // d->dump();
-    
+
     *logs << "route...\n";
     route(ds, max_passes);
 #ifndef NDEBUG
     d->check();
 #endif
-    
+
     if (output_file)
       {
         *logs << "write_txt " << output_file << "...\n";
@@ -648,23 +648,23 @@ main(int argc, const char **argv)
         ds.conf.write_txt(std::cout, chipdb, d, ds.placement, ds.cnet_net);
       }
   }
-  
+
   if (d)
     delete d;
-  
+
   /*
   }
   */
-  
+
   if (chipdb)
     delete chipdb;
-  
+
   logs = nullptr;
   if (null_ostream)
     {
       delete null_ostream;
       null_ostream = nullptr;
     }
-  
+
   return 0;
 }

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,15 +1,15 @@
 /* Copyright (C) 2015 Cotton Seed
-   
+
    This file is part of arachne-pnr.  Arachne-pnr is free software;
    you can redistribute it and/or modify it under the terms of the GNU
    General Public License version 2 as published by the Free Software
    Foundation.
-   
+
    This program is distributed in the hope that it will be useful, but
    WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
    General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
@@ -63,7 +63,7 @@ unescape(const std::string &s)
         {
           ++i;
           assert(i != s.end());
-          
+
           switch(*i)
             {
             case '\'':
@@ -182,7 +182,7 @@ std::string
 expand_filename(const std::string &file)
 {
   if (file[0] == '+')
-#ifdef _WIN32
+#if defined(_WIN32) && defined(MXE_DIR_STRUCTURE)
     return (proc_self_dirname()
             + std::string(file.begin() + 2,
                           file.end()));


### PR DESCRIPTION
Per [##openfpga discussion](https://irclog.whitequark.org/~h~openfpga/2018-02-19#1519051451-1519048841;), builds on Windows using msys2 should be using the Unix directory structure to avoid `chip-db` mismatches in case the user forgets to copy them to the invocation directory of the binary (relevant for both general usage and tests).

These changes to where `arachne-pnr` looks for `chip-db`s works fine w/ msys2; I do not have the ability to test with MXE, but the compiler command line looks correct in the `Makefile`.