### PR TITLE
Check SB_LVDS_INPUT against DPxxB

### DIFF
--- a/src/pcf.cc
+++ b/src/pcf.cc
@@ -247,7 +247,7 @@ ConstraintsPlacer::place()
               if (b != 3)
                 fatal(fmt("pcf error: LVDS port `" << p.first << "' not in bank 3\n"));
               if (loc.pos() != 0)
-                fatal(fmt("pcf error: LVDS port `" << p.first << "' not a DPxxA input\n"));
+                fatal(fmt("pcf error: LVDS port `" << p.first << "' not a DPxxB input\n"));
             }
           
           Location loc_other(t,

--- a/src/pcf.cc
+++ b/src/pcf.cc
@@ -241,10 +241,14 @@ ConstraintsPlacer::place()
               else
                 bank_latch[b] = latch;
             }
-          
-          if (inst->get_param("IO_STANDARD").as_string() == "SB_LVDS_INPUT"
-              && b != 3)
-            fatal(fmt("pcf error: LVDS port `" << p.first << "' not in bank 3\n"));
+
+          if (inst->get_param("IO_STANDARD").as_string() == "SB_LVDS_INPUT")
+            {
+              if (b != 3)
+                fatal(fmt("pcf error: LVDS port `" << p.first << "' not in bank 3\n"));
+              if (loc.pos() != 0)
+                fatal(fmt("pcf error: LVDS port `" << p.first << "' not a DPxxA input\n"));
+            }
           
           Location loc_other(t,
                              loc.pos() ? 0 : 1);


### PR DESCRIPTION
This patch checks if an LVDS input pin has been assigned to a DPxxA input, and aborts when it's a DPxxB input.

Without this patch, arachne asserts during the placement phase.

I don't know what the official Lattice tools do in such case. It's possible that it can deal with assignments to both inputs? In that case, for compatibility, it would be better for arachne to behave the same. But that'd be a much more complex fix.

This fixes issue #50 and issue #37.