### PR TITLE
emscripten: Improve mount points for accessing "real" files

### DIFF
--- a/src/arachne-pnr.cc
+++ b/src/arachne-pnr.cc
@@ -136,8 +136,10 @@ main(int argc, const char **argv)
   EM_ASM(
     if (ENVIRONMENT_IS_NODE)
     {
-      FS.mkdir('/x');
-      FS.mount(NODEFS, { root: '.' }, '/x');
+      FS.mkdir('/hostcwd');
+      FS.mount(NODEFS, { root: '.' }, '/hostcwd');
+      FS.mkdir('/hostfs');
+      FS.mount(NODEFS, { root: '/' }, '/hostfs');
     }
   );
 #endif


### PR DESCRIPTION
Instead of the previous `/x`, there is now `/hostcwd` for the current
directory and `/hostfs` for the root directory. (Due to limitations in
emscripten, it is not possible to simply make the real root filesystem
appear at / in the emscripten filesystem.)