### PR TITLE
Fix HFOSC/LFOSC and globals conflict

### DIFF
--- a/src/pcf.cc
+++ b/src/pcf.cc
@@ -426,6 +426,36 @@ ConstraintsPlacer::place()
         fatal("physical constraint required for IO_I3C");
       else if(models.is_io_od(inst))
         fatal("physical constraint required for IO_OD");
+      else if (models.is_lfosc(inst))
+        {
+          bool good = false;
+          for (int c : chipdb->cell_type_cells[cell_type_idx(CellType::LFOSC)])
+            {
+              if (cell_gate[c])
+                continue;
+              good = true;
+              cell_gate[c] = inst;
+              extend(ds.placement, inst, c);
+              break;
+            }
+          if (!good)
+            fatal("failed to place LFOSC");
+        }
+      else if (models.is_hfosc(inst))
+        {
+          bool good = false;
+          for (int c : chipdb->cell_type_cells[cell_type_idx(CellType::HFOSC)])
+            {
+              if (cell_gate[c])
+                continue;
+              good = true;
+              cell_gate[c] = inst;
+              extend(ds.placement, inst, c);
+              break;
+            }
+          if (!good)
+            fatal("failed to place HFOSC");
+        }
       else if (models.is_pllX(inst))
         {
           ++n_pll;


### PR DESCRIPTION
Previously arachne-pnr was only considering internal oscillators as occupying one global network each, without considering the different types of globals and what they can drive, when promoting globals. By moving oscillator placement to the constraints placement phase, these become known during global promotion and fix occasional conflicts, such as was occurring in tinyfpga/TinyFPGA-Bootloader#5