### PR TITLE
Fix test simple/sb_gb_io.

### DIFF
--- a/tests/simple/sb_gb_io.1k.pcf
+++ b/tests/simple/sb_gb_io.1k.pcf
@@ -1,1 +1,6 @@
 set_io inclk 50
+set_io out[0] 52
+set_io out[1] 56
+set_io out[2] 58
+set_io out[3] 60
+set_io outclk 61

--- a/tests/simple/sb_gb_io.8k.pcf
+++ b/tests/simple/sb_gb_io.8k.pcf
@@ -1,1 +1,6 @@
 set_io inclk F7
+set_io out[0] B9
+set_io out[1] D8
+set_io out[2] B8
+set_io out[3] A7
+set_io outclk C7


### PR DESCRIPTION
Commit 24f6b9c341910f6aaca1498872fe2e99ff8210cf broke the simple/sb_gb_io tests. This fixes it by adding proper set_io constraints.